### PR TITLE
Feature/tao 7613/flag to remove timestamps from export filename

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return [
     'label' => 'Export Tools',
     'description' => 'Extension providing tools dedicated to operations.',
     'license' => 'GPL-2.0',
-    'version' => '0.2.0',
+    'version' => '0.3.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=6.5.1',

--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return [
     'label' => 'Export Tools',
     'description' => 'Extension providing tools dedicated to operations.',
     'license' => 'GPL-2.0',
-    'version' => '0.3.0',
+    'version' => '0.4.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=6.5.1',

--- a/model/export/AllBookletsExport.php
+++ b/model/export/AllBookletsExport.php
@@ -150,6 +150,13 @@ class AllBookletsExport extends ConfigurableService
     private $exoticCharacters = [];
 
     /**
+     * If set to false - there would be no timestamp in filename
+     *
+     * @var bool
+     */
+    private $allowTimestampInFilename = true;
+
+    /**
      * @param string $identifierStrategy
      */
     public function setIdentifierStrategy($identifierStrategy)
@@ -170,7 +177,11 @@ class AllBookletsExport extends ConfigurableService
      */
     public function setPrefix($prefix)
     {
-        $this->prefix = rtrim($prefix,'_').'_';;
+        if ($this->allowTimestampInFilename) {
+            $this->prefix = rtrim($prefix,'_').'_';
+        } else {
+            $this->prefix = rtrim($prefix,'_');
+        }
     }
 
 
@@ -279,7 +290,10 @@ class AllBookletsExport extends ConfigurableService
         if (!is_null($this->dayToExport)) {
             $directory .= $this->dayToExport . DIRECTORY_SEPARATOR;
         }
-        $filename = $this->prefix. date('His') .'.csv';
+
+        $postfix = $this->allowTimestampInFilename ? date('His') : '';
+
+        $filename = $this->prefix. $postfix .'.csv';
 
         return $this->getServiceLocator()
             ->get(FileSystemService::SERVICE_ID)
@@ -993,5 +1007,10 @@ class AllBookletsExport extends ConfigurableService
             $this->exoticCharactersReplacementTable  = array_fill(0, count($this->getExoticVocabulary()), '');
         }
         return $this->exoticCharactersReplacementTable;
+    }
+
+    public function setAllowTimestampInFilename($allowTimestamp = true)
+    {
+        $this->allowTimestampInFilename = $allowTimestamp;
     }
 }

--- a/model/export/AllBookletsExport.php
+++ b/model/export/AllBookletsExport.php
@@ -298,10 +298,17 @@ class AllBookletsExport extends ConfigurableService
 
         $filename = $this->prefix. $postfix .'.csv';
 
-        return $this->getServiceLocator()
+        /** @var File $file */
+        $file = $this->getServiceLocator()
             ->get(FileSystemService::SERVICE_ID)
             ->getDirectory(self::FILESYSTEM_ID)
             ->getFile($directory . $filename);
+
+        if ($this->allowTimestampInFilename === false && $file->exists()) {
+            $file->delete();
+        }
+
+        return $file;
     }
 
     /**

--- a/scripts/tools/GenerateCsvFile.php
+++ b/scripts/tools/GenerateCsvFile.php
@@ -89,10 +89,10 @@ class GenerateCsvFile extends ScriptAction
             ],
 
             'withoutTimestamp' => [
-                'longprefix'    => 'without-timestamp',
+                'longPrefix'    => 'without-timestamp',
                 'prefix'        => 'wt',
                 'flag'          => true,
-                'description'   => "Setting this flag would mean that export file won't have timestamp postfix in filename",
+                'description'   => 'Setting this flag would mean that export file won\'t have timestamp postfix in filename',
                 'defaultValue'  => false,
                 'cast'          => 'boolean'
             ]

--- a/scripts/tools/GenerateCsvFile.php
+++ b/scripts/tools/GenerateCsvFile.php
@@ -88,6 +88,15 @@ class GenerateCsvFile extends ScriptAction
                 'description' => 'Allows export of exotic characters'
             ],
 
+            'withoutTimestamp' => [
+                'longprefix'    => 'without-timestamp',
+                'prefix'        => 'wt',
+                'flag'          => true,
+                'description'   => "Setting this flag would mean that export file won't have timestamp postfix in filename",
+                'defaultValue'  => false,
+                'cast'          => 'boolean'
+            ]
+
         ];
     }
 
@@ -129,6 +138,7 @@ class GenerateCsvFile extends ScriptAction
         $bookletExporter = $this->getServiceLocator()->get(AllBookletsExport::SERVICE_ID);
         $bookletExporter->setDeliveries($deliveries);
         $bookletExporter->setIdentifierStrategy($identifierStrategy);
+        $bookletExporter->setAllowTimestampInFilename($this->isTimestampNeeded());
         $bookletExporter->setPrefix($prefix);
         $bookletExporter->setVariablePolicy($variablePolicy);
         
@@ -195,5 +205,12 @@ class GenerateCsvFile extends ScriptAction
     protected function showTime()
     {
         return true;
+    }
+
+    private function isTimestampNeeded()
+    {
+        $withoutTimestamp = $this->getOption('withoutTimestamp', false);
+
+        return !(bool)$withoutTimestamp;
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -223,5 +223,7 @@ class Updater extends \common_ext_ExtensionUpdater
 
 
         }
+
+        $this->skip('0.2.0', '0.3.0');
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -220,6 +220,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.2.0');
         }
 
-        $this->skip('0.2.0', '0.3.0');
+        $this->skip('0.2.0', '0.4.0');
     }
 }


### PR DESCRIPTION
To check this:
* run script without `-wt` flag. Example:
`sudo -u www-data php index.php 'oat\taoResultExports\scripts\tools\GenerateCsvFile' -s title --policy all -p myDelivery`
Export file should contain timestamp in name;

* run script with `-wt` flag. Example:
`sudo -u www-data php index.php 'oat\taoResultExports\scripts\tools\GenerateCsvFile' -s title --policy all -p myDelivery -wt`
Export file shouldn't contain timestamp (and trailing underscore) in name;