### PR TITLE
Feature/tao 7246/fullname used for ltikvcache

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -24,7 +24,7 @@ return [
     'label' => 'Export Tools',
     'description' => 'Extension providing tools dedicated to operations.',
     'license' => 'GPL-2.0',
-    'version' => '0.2.0',
+    'version' => '0.3.0',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=6.5.1',

--- a/model/export/AllBookletsExport.php
+++ b/model/export/AllBookletsExport.php
@@ -22,12 +22,15 @@ namespace oat\taoResultExports\model\export;
 
 use oat\dtms\DateTime;
 use oat\generis\model\OntologyAwareTrait;
+use oat\generis\model\OntologyRdfs;
 use oat\oatbox\filesystem\File;
 use oat\oatbox\filesystem\FileSystemService;
 use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\user\User;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoDelivery\model\execution\ServiceProxy;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoLti\models\classes\user\UserService;
 use oat\taoResultServer\models\classes\ResultManagement;
 use oat\taoResultServer\models\classes\ResultServerService;
 use qtism\data\AssessmentTest;
@@ -553,14 +556,18 @@ class AllBookletsExport extends ConfigurableService
      */
     private function getRows()
     {
-
         $report = \common_report_Report::createSuccess();
+
+        /** @var UserService $userService */
+        $userService = $this->getServiceManager()->get(UserService::SERVICE_ID);
 
         $exportedResultsCount = 0;
         $i = 0;
         /** @var \core_kernel_classes_Resource $delivery */
         foreach($this->deliveries as $delivery){
             $deliveryUri = $delivery->getUri();
+
+            /** @var ResultManagement $storage */
             $storage = $this->getServiceLocator()->get(ResultServerService::SERVICE_ID)->getResultStorage($delivery);
 
             if(!$storage instanceof ResultManagement) {
@@ -572,16 +579,17 @@ class AllBookletsExport extends ConfigurableService
 
             foreach($results as $result){
                 /** @var DeliveryExecution $execution */
-                $execution = $execution = $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID)->getDeliveryExecution($result['deliveryResultIdentifier']);
+                $execution = $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID)->getDeliveryExecution($result['deliveryResultIdentifier']);
                 $row = array();
 
                 $startime = $this->cleanTimestamp($execution->getStartTime());
-                if (!is_null($this->dayToExport)  && $this->getEpochDay($startime) != $this->dayToExport) {
+                if (null !== $this->dayToExport && $this->getEpochDay($startime) !== $this->dayToExport) {
                     continue;
                 }
 
-                $user = $this->getResource($execution->getUserIdentifier());
-                $row['ID'] = $user->getLabel();
+                $user = $userService->getUserById($execution->getUserIdentifier());
+
+                $row['ID'] = $this->getUserId($user);
                 $row['IDFORM'] = $delivery->getLabel();
                 $row['STARTTIME'] = $startime;
                 $row['FINISHTIME'] = (($endTime = $execution->getFinishTime()) !== null) ? $this->cleanTimestamp($endTime) : '';
@@ -708,6 +716,13 @@ class AllBookletsExport extends ConfigurableService
         $report->setData($i);
 
         return $report;
+    }
+
+    private function getUserId(User $user)
+    {
+        $label = $user->getPropertyValues(OntologyRdfs::RDFS_LABEL);
+
+        return array_shift($label) ?: '';
     }
 
     /**

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -53,8 +53,6 @@ class Updater extends \common_ext_ExtensionUpdater
 
         $this->skip('0.1.0', '0.1.2');
 
-
-
         if ($this->isVersion('0.1.2') ){
             $bookletExporterService = $this->getServiceManager()->get(AllBookletsExport::SERVICE_ID);
             $vacbluary = [
@@ -220,8 +218,8 @@ class Updater extends \common_ext_ExtensionUpdater
             $bookletExporterService->setOption(AllBookletsExport::OPTION_EXOTIC_VOCABULARY, $vacbluary);
             $this->getServiceManager()->register(AllBookletsExport::SERVICE_ID, $bookletExporterService);
             $this->setVersion('0.2.0');
-
-
         }
+
+        $this->skip('0.2.0', '0.3.0');
     }
 }


### PR DESCRIPTION
Having LTI KV cache enabled we should have the full name of the test taker in the result of `oat\taoResultExports\scripts\tools\GenerateCsvFile`.