### PR TITLE
Fix: INV-299 inconsistent total scores fixed

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'Export Tools',
     'description' => 'Extension providing tools dedicated to operations.',
     'license' => 'GPL-2.0',
-    'version' => '0.7.0',
+    'version' => '0.7.1',
     'author' => 'Open Assessment Technologies',
     'requires' => [
         'generis' => '>=6.5.1',

--- a/model/export/AllBookletsExport.php
+++ b/model/export/AllBookletsExport.php
@@ -608,8 +608,8 @@ class AllBookletsExport extends ConfigurableService
                 $execution = $this->getServiceLocator()->get(ServiceProxy::SERVICE_ID)->getDeliveryExecution($result['deliveryResultIdentifier']);
                 $row = [];
 
-                $starTime = $this->cleanTimestamp($execution->getStartTime());
-                if (!$this->withinDateRange($starTime)) {
+                $startTime = $this->cleanTimestamp($execution->getStartTime());
+                if (!$this->withinDateRange($startTime)) {
                     continue;
                 }
 
@@ -617,7 +617,7 @@ class AllBookletsExport extends ConfigurableService
 
                 $row['ID'] = $this->getUserId($user);
                 $row['IDFORM'] = $delivery->getLabel();
-                $row['STARTTIME'] = $starTime;
+                $row['STARTTIME'] = $startTime;
                 $row['FINISHTIME'] = (($endTime = $execution->getFinishTime()) !== null) ? $this->cleanTimestamp($endTime) : '';
 
                 $itemCallIds = $storage->getRelatedItemCallIds($execution->getIdentifier());
@@ -722,7 +722,7 @@ class AllBookletsExport extends ConfigurableService
                     }
                 }
 
-                $row['SCORE'] = $this->getTotalScore($storage, $execution);
+                $row['SCORE'] = $this->fetchTotalScore($storage, $execution);
                 $row['ATTEMPT_ID'] = $execution->getIdentifier();
 
                 if (empty($row)) {
@@ -746,7 +746,7 @@ class AllBookletsExport extends ConfigurableService
         return $report;
     }
 
-    private function getTotalScore(ReadableResultStorage $storage, DeliveryExecution $deliveryExecution): int
+    private function fetchTotalScore(ReadableResultStorage $storage, DeliveryExecution $deliveryExecution): int
     {
         $testCallIds = $storage->getRelatedTestCallIds($deliveryExecution->getIdentifier());
 


### PR DESCRIPTION
Ticket: https://oat-sa.atlassian.net/browse/INV-299

Implemented fetching a total score for a delivery execution from a test outcome variable instead of summarizing item scores including duplicates created when a test taker answer questions multiple times.