### PR TITLE
INV-344 removed hidden special characters from the item label

### DIFF
--- a/model/export/AllBookletsExport.php
+++ b/model/export/AllBookletsExport.php
@@ -564,6 +564,7 @@ class AllBookletsExport extends ConfigurableService
             }
 
             $headers = array_merge($headers, ['SCORE', 'ATTEMPT_ID']);
+            $headers = array_map([$this, 'removeHiddenCharacters'], $headers);
 
             $this->headers = array_unique($headers);
         }
@@ -900,6 +901,8 @@ class AllBookletsExport extends ConfigurableService
         }
 
         foreach ($neededColumns as $column) {
+            $column = $this->removeHiddenCharacters($column);
+
             if (!in_array($column, array_keys($row))) {
                 $row[$column] = $this->determineMissingDataEncoding($this->getOption(self::NOT_ATTEMPTED_OPTION), $column);
             }
@@ -1079,5 +1082,10 @@ class AllBookletsExport extends ConfigurableService
     public function setAllowTimestampInFilename($allowTimestamp = true)
     {
         $this->allowTimestampInFilename = $allowTimestamp;
+    }
+
+    protected function removeHiddenCharacters(string $field): string
+    {
+        return preg_replace('/[\x00-\x1F\x80-\xFF]/', '', $field);
     }
 }


### PR DESCRIPTION
This PR aims to solve the issue: https://oat-sa.atlassian.net/browse/INV-344

**Currently**, it may be possible to add items with special characters hidden inside the label in tests, and when exporting results, these characters are shown
.
**The solution**: to maintain the consistency that the user can see on the label, we are removing these special characters when exporting the result.