### PR TITLE
fix: Fix oat-sa/lib-tao-dtms with version for tao-community

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "oat-sa/extension-tao-lti" : ">=12.0.0",
         "oat-sa/extension-tao-outcome" : ">=13.0.0",
         "oat-sa/extension-tao-outcomerds" : ">=8.0.0",
-        "oat-sa/lib-tao-dtms": "1.0.0"
+        "oat-sa/lib-tao-dtms": "^1.0.1"
     },
     "minimum-stability" : "dev",
     "autoload" : {


### PR DESCRIPTION
This PR aims at solving issue [LSI-1449](https://oat-sa.atlassian.net/browse/LSI-1449) for `tao-enterprise-invalsi` for PHP 8.1 where it is not possible to upgrade to the latest release of `oat-sa/extension-tao-result-export` because it depends strictly on library `oat-sa/lib-tao-dtms` : `1.0.0` , while `oat-sa/extension-tao-eventlog` depends on `oat-sa/lib-tao-dtms` : `^1.0.1`. We have a version conflict!

(can be tested in branch https://github.com/oat-sa/tao-enterprise-invalsi/tree/release/2022.11 as a temporary solution)

More information in ticket [LSI-1449](https://oat-sa.atlassian.net/browse/LSI-1449).